### PR TITLE
QueryBuilder Providers

### DIFF
--- a/Controller/FilterController.php
+++ b/Controller/FilterController.php
@@ -39,6 +39,7 @@ use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use whatwedo\TableBundle\Entity\Filter;
 use whatwedo\TableBundle\Enum\FilterStateEnum;
 use whatwedo\TableBundle\Event\ResultRequestEvent;
+use whatwedo\TableBundle\Manager\QueryBuilderManager;
 
 class FilterController extends AbstractController
 {

--- a/Controller/FilterController.php
+++ b/Controller/FilterController.php
@@ -57,11 +57,17 @@ class FilterController extends AbstractController
      */
     private $eventDispatcher;
 
-    public function __construct(RouterInterface $router, EntityManagerInterface $entityManager, EventDispatcherInterface $eventDispatcher)
+    /**
+     * @var QueryBuilderManager
+     */
+    private $queryBuilderManager;
+
+    public function __construct(RouterInterface $router, EntityManagerInterface $entityManager, EventDispatcherInterface $eventDispatcher, QueryBuilderManager $queryBuilderManager)
     {
         $this->router = $router;
         $this->entityManager = $entityManager;
         $this->eventDispatcher = $eventDispatcher;
+        $this->queryBuilderManager = $queryBuilderManager;
     }
 
     /**
@@ -128,8 +134,8 @@ class FilterController extends AbstractController
         $class = $request->get('entity');
         $term = $request->get('q');
         $resultRequestEvent = new ResultRequestEvent($class, $term);
+        $resultRequestEvent->setQueryBuilder($this->queryBuilderManager->getQueryBuilderForEntity($class));
         $this->eventDispatcher->dispatch($resultRequestEvent, ResultRequestEvent::FILTER_SET);
-
         return $resultRequestEvent->getResult();
     }
 }

--- a/DependencyInjection/whatwedoTableExtension.php
+++ b/DependencyInjection/whatwedoTableExtension.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use whatwedo\TableBundle\Extension\ExtensionInterface;
+use whatwedo\TableBundle\Provider\QueryBuilderProvider;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -24,5 +25,6 @@ class whatwedoTableExtension extends Extension
         $loader->load('services.yml');
 
         $container->registerForAutoconfiguration(ExtensionInterface::class)->addTag('table.extension');
+        $container->registerForAutoconfiguration(QueryBuilderProvider::class)->addTag('table_bundle.query_builder_provider');
     }
 }

--- a/Manager/QueryBuilderManager.php
+++ b/Manager/QueryBuilderManager.php
@@ -50,8 +50,11 @@ class QueryBuilderManager
     {
         /** @var QueryBuilderProvider[] $matchingProviders */
         $matchingProviders = array_filter(iterator_to_array($this->queryBuilderProviders), function(QueryBuilderProvider $provider) use ($class) {
-            return $provider->getEntity() === $class;
+            return $provider->getEntity() === $class
+                && $provider->getAllowedSubclasses()
+                && in_array(get_class($provider), $provider->getAllowedSubclasses());
         });
+        $matchingProviders = array_values($matchingProviders);
         if ($matchingProviders && count($matchingProviders) > 1) {
             throw Exception('Multiple query-builder-providers found. It is not clear, which to use.');
         }

--- a/Manager/QueryBuilderManager.php
+++ b/Manager/QueryBuilderManager.php
@@ -55,10 +55,10 @@ class QueryBuilderManager
                 && in_array(get_class($provider), $provider->getAllowedSubclasses());
         });
         $matchingProviders = array_values($matchingProviders);
-        if ($matchingProviders && count($matchingProviders) > 1) {
+        if (count($matchingProviders) > 1) {
             throw Exception('Multiple query-builder-providers found. It is not clear, which to use.');
         }
-        if (!$matchingProviders || count($matchingProviders) < 1) {
+        if (count($matchingProviders) === 0) {
             return null;
         }
         return $matchingProviders[0]->getQueryBuilder();

--- a/Manager/QueryBuilderManager.php
+++ b/Manager/QueryBuilderManager.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright (c) 2021, whatwedo GmbH
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace whatwedo\TableBundle\Manager;
+
+
+use Doctrine\ORM\QueryBuilder;
+use whatwedo\TableBundle\Provider\QueryBuilderProvider;
+
+/**
+ * @author Timo Bühlmann
+ */
+class QueryBuilderManager
+{
+    protected iterable $queryBuilderProviders;
+
+    public function __construct(iterable $queryBuilderProviders)
+    {
+        $this->queryBuilderProviders = $queryBuilderProviders;
+    }
+
+    /**
+     * @return QueryBuilder|null
+     */
+    public function getQueryBuilderForEntity(string $class)
+    {
+        /** @var QueryBuilderProvider[] $matchingProviders */
+        $matchingProviders = array_filter(iterator_to_array($this->queryBuilderProviders), function(QueryBuilderProvider $provider) use ($class) {
+            return $provider->getEntity() === $class;
+        });
+        if ($matchingProviders && count($matchingProviders) > 1) {
+            throw Exception('Multiple query-builder-providers found. It is not clear, which to use.');
+        }
+        if (!$matchingProviders || count($matchingProviders) < 1) {
+            return null;
+        }
+        return $matchingProviders[0]->getQueryBuilder();
+    }
+
+    public function getQueryBuilderProviders(): iterable
+    {
+        return $this->queryBuilderProviders;
+    }
+}

--- a/Provider/QueryBuilderProvider.php
+++ b/Provider/QueryBuilderProvider.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright (c) 2021, whatwedo GmbH
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace whatwedo\TableBundle\Provider;
+
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @author Timo Bühlmann
+ */
+interface QueryBuilderProvider
+{
+    /**
+     * @return QueryBuilder
+     */
+    public function getQueryBuilder();
+    /**
+     * @return string
+     */
+    public static function getEntity();
+}

--- a/Provider/QueryBuilderProvider.php
+++ b/Provider/QueryBuilderProvider.php
@@ -43,4 +43,10 @@ interface QueryBuilderProvider
      * @return string
      */
     public static function getEntity();
+    /**
+     * If subclasses (e.g definitions) support the same entity, only the parent class is recommended.
+     *
+     * @return string[]
+     */
+    public static function getAllowedSubclasses();
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -29,4 +29,4 @@ services:
 
     whatwedo\TableBundle\Manager\QueryBuilderManager:
         arguments:
-            - !tagged_iterator 'query_builder_provider'
+            - !tagged_iterator 'table_bundle.query_builder_provider'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,3 +26,7 @@ services:
       tags:
             - { name: kernel.event_listener, event: whatwedo_ajax.result_request.filter_set, method: searchResultSet, priority: 100 }
             - { name: kernel.event_listener, event: whatwedo_ajax.result_request.relation_set, method: searchResultSet, priority: 100 }
+
+    whatwedo\TableBundle\Manager\QueryBuilderManager:
+        arguments:
+            - !tagged_iterator 'query_builder_provider'

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
         {
             "name": "Nicolo Singer",
             "email": "nicolo@whatwedo.ch"
+        },
+        {
+            "name": "Timo Bühlmann",
+            "email": "timo@whatwedo.ch"
         }
     ],
     "require": {
@@ -32,6 +36,11 @@
     "autoload": {
         "psr-4": {
             "whatwedo\\TableBundle\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-feature/query-builder-provider": "0.4.x-dev"
         }
     }
 }


### PR DESCRIPTION
Ich habe ein Interface eingebaut (`QueryBuilderProvider`), welches man biespielsweise auf Definitions anwenden kann. Der FilterController schaut dann automatisch, ob es einen Provider gibt, der die entsprechende Entity unterstützt und wendet gegebenenfalls den entsprechenden QueryBuilder an.  

Diese Anforderung ist daraus entstanden, dass häufig in den Definitions schon QueryBuilder definiert hat, welche in den Filter auch angewendet werden sollten.  