### PR TITLE
Deprecations

### DIFF
--- a/Extension/FilterExtension.php
+++ b/Extension/FilterExtension.php
@@ -397,7 +397,7 @@ class FilterExtension extends AbstractExtension
 
     private function getFromRequest(string $param)
     {
-        $value = $this->getRequest()->query->get($this->getActionQueryParameter($param), []);
+        $value = $this->getRequest()->query->get($this->getActionQueryParameter($param)) ?: [];
         $predefined = $this->getPredefinedFilter($this->getRequest()->query->get($this->getActionQueryParameter(static::QUERY_PREDEFINED_FILTER), ''));
 
         return $predefined ? array_merge($value, $predefined[$param]) : $value;

--- a/Table/Table.php
+++ b/Table/Table.php
@@ -149,7 +149,11 @@ class Table
     ) {
         $this->identifier = $identifier;
         $this->eventDispatcher = $eventDispatcher;
-        $this->request = $requestStack->getMasterRequest();
+        if (\is_callable([$requestStack, 'getMainRequest'])) {
+            $this->request = $requestStack->getMainRequest();   // symfony 5.3+
+        } else {
+            $this->request = $requestStack->getMasterRequest();
+        }
         $this->templating = $templating;
         $this->extensions = $extensions;
         $this->formatterManager = $formatterManager;

--- a/Twig/TableExtension.php
+++ b/Twig/TableExtension.php
@@ -77,7 +77,11 @@ class TableExtension extends AbstractExtension
              * generates the same route with replaced or new arguments
              */
             new TwigFunction('whatwedo_table_generate_route_replace_arguments', function ($arguments) {
-                $request = $this->requestStack->getMasterRequest();
+                if (\is_callable([$this->requestStack, 'getMainRequest'])) {
+                    $request = $this->requestStack->getMainRequest();   // symfony 5.3+
+                } else {
+                    $request = $this->requestStack->getMasterRequest();
+                }
                 $attributes = array_filter($request->attributes->all(), function ($key) {
                     return 0 !== mb_strpos($key, '_');
                 }, ARRAY_FILTER_USE_KEY);


### PR DESCRIPTION
- `Since symfony/http-foundation 5.1: Passing a non-scalar value as 2nd argument to "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, pass a scalar or null instead.`
- `Since symfony/http-foundation 5.3: "Symfony\Component\HttpFoundation\RequestStack::getMasterRequest()" is deprecated, use "getMainRequest()" instead.`