### PR TITLE
fix(Filter): filters shouldn't add more body tags

### DIFF
--- a/src/Resources/assets/controllers/filter_controller.js
+++ b/src/Resources/assets/controllers/filter_controller.js
@@ -28,7 +28,10 @@ export default class extends Controller {
         const parser = new DOMParser();
         const template = choosenOption.getAttribute('data-value-template')
         const doc = parser.parseFromString(template.replace(/{name}/g, valueField.getAttribute('name')), 'text/html');
-        valueField.parentNode.replaceChild(doc.body, valueField);
+        if(!doc.body?.childNodes?.[0]) {
+          throw new Error('No template found');
+        }
+        valueField.parentNode.replaceChild(doc.body.childNodes[0], valueField);
     }
 
     open() {


### PR DESCRIPTION
There is an issue with changing from one filter to another with the "filter target" dropdown. If you change a filter, the stimulus controller will add a body tag with the filter element inside it. If you repeat doing that, you will have N amount of body tags in your DOM.

<img width="277" height="234" alt="image" src="https://github.com/user-attachments/assets/462abbf9-dc09-493b-b56d-98e6916374e3" />
